### PR TITLE
remove reliance on ES2015 Array/Object functions

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -1,9 +1,10 @@
 import Rule from './rule';
 import update from './update';
+import { some, assign} from './utils';
 
 export default class Form {
   constructor(options = {}) {
-    Object.assign(this, {
+    assign(this, {
       observe: function() {},
       rules: {},
       object: null,
@@ -12,7 +13,7 @@ export default class Form {
       }
     }, options);
     this.rule = new Rule({
-      isRequired: Object.keys(this.rules).some((k)=> {
+      isRequired: some(Object.keys(this.rules), (k)=> {
         return this.rules[k].isRequired;
       }),
       rules: this.rules,
@@ -33,7 +34,7 @@ export default class Form {
 
   reset() {
     this.rule = new Rule({
-      isRequired: Object.keys(this.rules).some((k)=> {
+      isRequired: some(Object.keys(this.rules), (k) => {
         return this.rules[k].isRequired;
       }),
       rules: this.rules,
@@ -91,11 +92,11 @@ export default class Form {
 
 class FormState {
   constructor(previous = {}, change = ()=>{}) {
-    Object.assign(this, {}, previous);
+    assign(this, {}, previous);
     if (change.call) {
       change.call(this, this);
     } else {
-      Object.assign(this, change);
+      assign(this, change);
     }
 
     this.buffer = this.buffer || this.value;
@@ -106,7 +107,7 @@ class FormState {
 
   set(key, value) {
     return new FormState(this, {
-      buffer: Object.assign({}, this.buffer, {
+      buffer: assign({}, this.buffer, {
         [key]: value
       })
     });
@@ -132,7 +133,7 @@ class FormState {
         if (this.object) {
           value = this.read(this.object, name);
         }
-        return Object.assign(buffer, {[name]: value});
+        return assign(buffer, {[name]: value});
       }, {});
     }
     return this._value;

--- a/src/rule.js
+++ b/src/rule.js
@@ -1,8 +1,9 @@
 import update from './update';
+import { assign, some, every } from './utils';
 
 export default class Rule {
   constructor(options = {}) {
-    Object.assign(this, {
+    assign(this, {
       isRequired: false,
       condition: function(input, resolve) { resolve(); },
       observe: function() {},
@@ -12,17 +13,17 @@ export default class Rule {
 
     let keys = this.keys = Object.keys(this.rules);
     this.rules = keys.reduce((rules, key)=> {
-      return Object.assign(rules, {[key]: new Rule(Object.assign(options.rules[key], {
+      return assign(rules, {[key]: new Rule(assign(options.rules[key], {
         context: this.context,
         observe: (state) => {
           update(this, (next)=> {
-            next.rules = Object.assign({}, next.rules, {[key]: state});
+            next.rules = assign({}, next.rules, {[key]: state});
           });
           if (state.isRejected) {
             this.reject();
-          } else if (this.prereqs.every((p)=> p.state.isFulfilled)) {
+          } else if (every(this.prereqs, (p)=> p.state.isFulfilled)) {
             this.evaluateCondition(state.input);
-          } else if (this.prereqs.some((p)=> p.state.isPending)) {
+          } else if (some(this.prereqs, (p)=> p.state.isPending)) {
             this.start();
           } else {
             this.idle();
@@ -38,7 +39,7 @@ export default class Rule {
       isFulfilled: !this.isRequired,
       isRejected: false,
       rules: keys.reduce((rules, key)=> {
-        return Object.assign(rules, {[key]: this.rules[key].state });
+        return assign(rules, {[key]: this.rules[key].state });
       }, {})
     });
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,10 @@
 export function assign(object, ...hashes) {
   for (let i = 0; i < hashes.length; i++) {
     let hash = hashes[i];
-    for (let key in hash) {
+    let keys = Object.keys(hash);
+
+    for (let i = 0; i < keys.length; i++) {
+      let key = keys[i];
       object[key] = hash[key];
     }
   }
@@ -10,8 +13,14 @@ export function assign(object, ...hashes) {
 }
 
 // Array.prototype.some
-export function some(array, ...rest) {
-  return array.filter.apply(array, rest).length > 0;
+export function some(array, callback, thisArg=array) {
+  for (let i = 0; i < array.length; i++) {
+    let thing = array[i];
+    if (callback.call(thisArg, thing)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function every(array, ...rest) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,19 @@
+// subset of Object.assign
+export function assign(object, ...hashes) {
+  for (let i = 0; i < hashes.length; i++) {
+    let hash = hashes[i];
+    for (let key in hash) {
+      object[key] = hash[key];
+    }
+  }
+  return object;
+}
+
+// Array.prototype.some
+export function some(array, ...rest) {
+  return array.filter.apply(array, rest).length > 0;
+}
+
+export function every(array, ...rest) {
+  return array.filter.apply(array, rest).length === array.length;
+}


### PR DESCRIPTION
With a small amount of code, we can make it so users don't have
to pick out the correct polyfill code to load. This lets the library
run in non-evergreen browsers and IE10/11.
